### PR TITLE
Add message to header to redirect new users to Spezi

### DIFF
--- a/index.html
+++ b/index.html
@@ -74,7 +74,7 @@
         <div class="info" style="padding: 5em">
                 <h1>The next generation of CardinalKit is here!</h1>
                 <h2>
-                  <strong>Stanford Spezi</strong> is a standards-based, modular framework for developing digital health applications.
+                  <a href="https://spezi.stanford.edu" style="color: white; text-decoration: underline">Stanford Spezi</a> is a standards-based, modular framework for developing digital health applications.
                 </h2>
                 <a href="https://spezi.stanford.edu" target="_blank" class="fl btn accent interact">Get Started With Spezi</a>
         </div> 

--- a/index.html
+++ b/index.html
@@ -71,11 +71,12 @@
     </div>
   </div>
   <div class="navPusher">
-        <div class="info">
-            <p style="font-weight: 400">
-                The next generation of CardinalKit is <strong>Stanford Spezi</strong>, a standards-based modular framework for developing digital health applications. <br />
-                Learn more at <a href="https://spezi.stanford.edu" target="_blank" style="color: white; text-decoration: underline; font-weight: 700">spezi.stanford.edu</a>.
-            </p>
+        <div class="info" style="padding: 5em">
+                <h1>The next generation of CardinalKit is here!</h1>
+                <h2>
+                  <strong>Stanford Spezi</strong> is a standards-based, modular framework for developing digital health applications.
+                </h2>
+                <a href="https://spezi.stanford.edu" target="_blank" class="fl btn accent interact">Get Started With Spezi</a>
         </div> 
     <div class="container" style="user-select: auto" style="position: relative">
       <div class="pure-g" style="user-select: auto">
@@ -211,7 +212,7 @@
         <div class="fl-card">
           <div class="pure-g" style="user-select: auto">
             <div class="pure-u-1 pure-u-lg-1-2">
-              <h2>CardinalKit Android (new!)</h2>
+              <h2>CardinalKit Android</h2>
               <div class="sub"></div>
               <br />
               <p>


### PR DESCRIPTION
<!--

This source file is part of the CardinalKit open-source project

SPDX-FileCopyrightText: 2022 CardinalKit and the project authors (see CONTRIBUTORS.md)

SPDX-License-Identifier: MIT

-->

# Add message to header to redirect new users to Spezi

## :recycle: Current situation & Problem
CardinalKit is now in maintenance mode and not receiving new feature updates. All new iOS projects should use [Stanford Spezi](https://spezi.stanford.edu)


## :gear: Release Notes 
Adds a prominent message in the header that directs new users to Spezi.

### Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md):
- [X] I agree to follow the [Code of Conduct](https://github.com/CardinalKit/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/CardinalKit/.github/blob/main/CONTRIBUTING.md).

